### PR TITLE
[#165646609] Fix For MoPub Ads Not Updating Orientation Back To Portrait When Closed

### DIFF
--- a/MoPubSDK/Internal/Interstitials/MPInterstitialViewController.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialViewController.m
@@ -9,6 +9,7 @@
 
 #import "MPGlobal.h"
 #import "MPLogging.h"
+#import "Skillz_private.h"
 #import "UIButton+MPAdditions.h"
 #import "UIApplication+Skillz.h"
 #import "UIView+Skillz.h"
@@ -170,6 +171,11 @@ static NSString * const kCloseButtonXImageName = @"MPCloseButtonX.png";
 
 - (void)dismissInterstitialAnimated:(BOOL)animated
 {
+    if (UIInterfaceOrientationIsLandscape([NSUserDefaults currentSDKOrientation]) && hasNotchedDisplay()) {
+        dispatch_async(dispatch_get_main_queue(), ^{
+            [[Skillz skillzInstance].navigationController updateControllerForPortraitOrientation];
+        });
+    }
     [self setApplicationStatusBarHidden:!self.applicationHasStatusBar];
 
     [self willDismissInterstitial];


### PR DESCRIPTION
- Added a check that will make sure that if we are using a Landscape notched device, then we should update the orientation back to Portrait when the interstitial ad is closed.
- When hitting Play Again and seeing a Landscape ad, we don't have to worry about this orientation update since Versus will change the orientation to Landscape anyway when playing a Landscape game.