### PR TITLE
[PS-9221] update the VC presentation style to FullScreen for iOS 13

### DIFF
--- a/MoPubSDK/Internal/MPInstanceProvider.m
+++ b/MoPubSDK/Internal/MPInstanceProvider.m
@@ -179,6 +179,7 @@ static MPInstanceProvider *sharedAdProvider = nil;
                                                                             configuration:(MPAdConfiguration *)configuration
 {
     MPMRAIDInterstitialViewController *controller = [[MPMRAIDInterstitialViewController alloc] initWithAdConfiguration:configuration];
+    [controller setModalPresentationStyle:UIModalPresentationFullScreen];
     controller.delegate = delegate;
     return controller;
 }

--- a/MoPubSDK/RewardedVideo/Internal/MPMoPubRewardedPlayableCustomEvent.m
+++ b/MoPubSDK/RewardedVideo/Internal/MPMoPubRewardedPlayableCustomEvent.m
@@ -33,6 +33,7 @@ const NSTimeInterval kDefaultCountdownTimerIntervalInSeconds = 30;
     if (_interstitial == nil) {
         _interstitial = [[MPMRAIDInterstitialViewController alloc] initWithAdConfiguration:self.delegate.configuration];
     }
+    [_interstitial setModalPresentationStyle:UIModalPresentationFullScreen];
 
     return _interstitial;
 }


### PR DESCRIPTION
iOS 13's default way of displaying view controller will be to present as a modal.

This PR would update the relevant view controllers' presentation style to full screen.
Although if a web view is presented as a response to tapping the ad it'd be presented as the Modal View because it could be dismissed (makes sense to use the default behavior in iOS13 for dismissible modals).