### PR TITLE
[PS-26339] remove NSAssert when a nil or empty ad unit id is passed

### DIFF
--- a/MoPubSDK/Internal/MPConsentManager.m
+++ b/MoPubSDK/Internal/MPConsentManager.m
@@ -543,7 +543,11 @@ static NSString * const kMacroReplaceLanguageCode = @"%%LANGUAGE%%";
     if (self.adUnitIdUsedForConsent.length == 0) {
         NSString * description = @"Warning: no ad unit available for GDPR sync. Please make sure that the SDK is initialized correctly via `initializeSdkWithConfiguration:completion:` as soon as possible after app startup.";
         MPLogInfo(@"%@", description);
-        NSAssert(NO, description); // Crash the app if this is set up incorrectly
+        /* We don't want to crash the app if there is a nil or empty ad unit ID.
+         * If there is a nil or empty ad unit ID, the GDPR sync will retry in the
+         * next timer interval.
+         */
+        // NSAssert(NO, description); // Crash the app if this is set up incorrectly
     } else {
         MPLogDebug(@"Ad unit used for GDPR sync: %@", self.adUnitIdUsedForConsent);
     }


### PR DESCRIPTION
- Removed the NSAssert.
   - This way if the server endpoint for grabbing the ad unit ids fail, the GDPR sync will try again in the next timer interval. 
      Hopefully by the next timer interval, a successful call to server for the Mopub ad units will have been made and Mopub can complete the GDPR sync.
- This should not be a bypass for not setting up proper ad unit ids for a system segment/game id. Server should always be looking to send down valid ad units for the /v1/ads/mopub call