### PR TITLE
[PS-28609] dismiss interstitial ad when deeplinking to store

### DIFF
--- a/MoPubSDK/Internal/Fullscreen/MPFullscreenAdViewController+Web.m
+++ b/MoPubSDK/Internal/Fullscreen/MPFullscreenAdViewController+Web.m
@@ -153,7 +153,7 @@
 }
 
 - (void)adActionDidFinish:(MPWebView *)ad {
-    //NOOP: the landing page is going away, but not the interstitial.
+    [self dismiss];
 }
 
 - (void)adWebViewAgentDidReceiveTap:(MPAdWebViewAgent *)aAdWebViewAgent {


### PR DESCRIPTION
Dismiss interstitial ad when tapping on ad to dismiss deeplink. Ads set to deeplink outside of the app still bring up a webview with the url and shows the ad still when you dismiss the webview.
![ios-ad-deeplink](https://user-images.githubusercontent.com/22797037/95617992-25d75680-0a21-11eb-8378-93a2f0bbc772.gif)
