### PR TITLE
[PS-28599] fix tap interaction with mopub ad

### DIFF
--- a/MoPubSDK/Internal/Common/MPProgressOverlayView.m
+++ b/MoPubSDK/Internal/Common/MPProgressOverlayView.m
@@ -52,7 +52,6 @@
             button.hidden = YES;    // Set to hidden to participate in autoresizing, but not capture user input
 
             [button addTarget:self action:@selector(closeButtonPressed) forControlEvents:UIControlEventTouchUpInside];
-
             [button setImage:[UIImage imageForAsset:kMPImageAssetCloseButton] forState:UIControlStateNormal];
             [button sizeToFit];
             button;

--- a/MoPubSDK/Internal/Fullscreen/MPFullscreenAdViewController+Web.m
+++ b/MoPubSDK/Internal/Fullscreen/MPFullscreenAdViewController+Web.m
@@ -153,11 +153,15 @@
 }
 
 - (void)adActionDidFinish:(MPWebView *)ad {
-    [self dismiss];
+    //NOOP: the landing page is going away, but not the interstitial.
 }
 
 - (void)adWebViewAgentDidReceiveTap:(MPAdWebViewAgent *)aAdWebViewAgent {
     [self.webAdDelegate fullscreenWebAdDidReceiveTap:self];
+}
+
+- (void)dismissInterstitial {
+    [self dismiss];
 }
 
 @end

--- a/MoPubSDK/Internal/HTML/MPAdWebViewAgent.h
+++ b/MoPubSDK/Internal/HTML/MPAdWebViewAgent.h
@@ -110,6 +110,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)adActionWillLeaveApplication:(MPWebView *)ad;
 - (void)adActionDidFinish:(MPWebView *)ad;
 - (void)adWebViewAgentDidReceiveTap:(MPAdWebViewAgent *)aAdWebViewAgent;
+- (void)dismissInterstitial;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
+++ b/MoPubSDK/Internal/HTML/MPAdWebViewAgent.m
@@ -241,6 +241,7 @@
     NSURL *URL = [request URL];
     if ([URL.scheme isEqualToString:SKZ_DEEP_LINK_SCHEME]) {
         [[Skillz skillzInstance] openDeepLinkingURLFromMoPub:URL];
+        [self.delegate dismissInterstitial];
     }
     
     // Web view request handling has been disabled. Ignore this load.

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.h
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.h
@@ -20,5 +20,5 @@
 
 - (void)loadInterstitialWithAdUnitID:(NSString *)ID targeting:(MPAdTargeting *)targeting;
 - (void)presentInterstitialFromViewController:(UIViewController *)controller;
-- (void)dismissInterstitialAnimated:(BOOL)animated;
+
 @end

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -25,6 +25,7 @@
 #import "NSMutableArray+MPAdditions.h"
 #import "NSDate+MPAdditions.h"
 #import "NSError+MPAdditions.h"
+#import "Skillz+MoPub.h"
 
 @interface MPInterstitialAdManager ()
 
@@ -145,6 +146,7 @@
     if (configuration.adUnitWarmingUp) {
         MPLogInfo(kMPWarmingUpErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId);
         self.loading = NO;
+        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:configuration.creativeId];
         [self.delegate manager:self didFailToLoadInterstitialWithError:[NSError errorWithCode:MOPUBErrorAdUnitWarmingUp]];
         return;
     }
@@ -152,6 +154,7 @@
     if ([configuration.adType isEqualToString:kAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId);
         self.loading = NO;
+        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:configuration.creativeId];
         [self.delegate manager:self didFailToLoadInterstitialWithError:[NSError errorWithCode:MOPUBErrorNoInventory]];
         return;
     }
@@ -164,6 +167,10 @@
     self.ready = NO;
     self.loading = NO;
 
+    MPAdConfiguration *config = self.requestingConfiguration;
+    if (config != nil) {
+        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:config.creativeId];
+    }
     [self.delegate manager:self didFailToLoadInterstitialWithError:error];
 }
 
@@ -209,6 +216,9 @@
 - (void)adAdapter:(id<MPAdAdapter>)adapter handleFullscreenAdEvent:(MPFullscreenAdEvent)fullscreenAdEvent {
     switch (fullscreenAdEvent) {
         case MPFullscreenAdEventDidLoad:
+            if (self.requestingConfiguration != nil) {
+                [[Skillz skillzInstance] setLoadedInterstitialCreativeId:self.requestingConfiguration.creativeId];
+            }
             self.remainingConfigurations = nil;
             self.ready = YES;
             self.loading = NO;
@@ -289,7 +299,11 @@
     else {
         self.ready = NO;
         self.loading = NO;
-
+        
+        MPAdConfiguration *config = self.requestingConfiguration;
+        if (config != nil) {
+            [[Skillz skillzInstance] setLoadedInterstitialCreativeId:config.creativeId];
+        }
         NSError * clearResponseError = [NSError errorWithCode:MOPUBErrorNoInventory localizedDescription:[NSString stringWithFormat:kMPClearErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId]];
         MPLogAdEvent([MPLogEvent adFailedToLoadWithError:clearResponseError], self.delegate.interstitialAdController.adUnitId);
         [self.delegate manager:self didFailToLoadInterstitialWithError:clearResponseError];

--- a/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
+++ b/MoPubSDK/Internal/Interstitials/MPInterstitialAdManager.m
@@ -25,7 +25,6 @@
 #import "NSMutableArray+MPAdditions.h"
 #import "NSDate+MPAdditions.h"
 #import "NSError+MPAdditions.h"
-#import "Skillz+MoPub.h"
 
 @interface MPInterstitialAdManager ()
 
@@ -112,11 +111,6 @@
     [self.adapter showFullscreenAdFromViewController:controller];
 }
 
-- (void)dismissInterstitialAnimated:(BOOL)animated
-{
-    [self.adapter dismissInterstitialAnimated:animated];
-}
-
 - (MPInterstitialAdController *)interstitialAdController
 {
     return [self.delegate interstitialAdController];
@@ -151,7 +145,6 @@
     if (configuration.adUnitWarmingUp) {
         MPLogInfo(kMPWarmingUpErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId);
         self.loading = NO;
-        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:configuration.creativeId];
         [self.delegate manager:self didFailToLoadInterstitialWithError:[NSError errorWithCode:MOPUBErrorAdUnitWarmingUp]];
         return;
     }
@@ -159,7 +152,6 @@
     if ([configuration.adType isEqualToString:kAdTypeClear]) {
         MPLogInfo(kMPClearErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId);
         self.loading = NO;
-        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:configuration.creativeId];
         [self.delegate manager:self didFailToLoadInterstitialWithError:[NSError errorWithCode:MOPUBErrorNoInventory]];
         return;
     }
@@ -172,10 +164,6 @@
     self.ready = NO;
     self.loading = NO;
 
-    MPAdConfiguration *config = self.requestingConfiguration;
-    if (config != nil) {
-        [[Skillz skillzInstance] setLoadedInterstitialCreativeId:config.creativeId];
-    }
     [self.delegate manager:self didFailToLoadInterstitialWithError:error];
 }
 
@@ -221,9 +209,6 @@
 - (void)adAdapter:(id<MPAdAdapter>)adapter handleFullscreenAdEvent:(MPFullscreenAdEvent)fullscreenAdEvent {
     switch (fullscreenAdEvent) {
         case MPFullscreenAdEventDidLoad:
-            if (self.requestingConfiguration != nil) {
-                [[Skillz skillzInstance] setLoadedInterstitialCreativeId:self.requestingConfiguration.creativeId];
-            }
             self.remainingConfigurations = nil;
             self.ready = YES;
             self.loading = NO;
@@ -304,11 +289,7 @@
     else {
         self.ready = NO;
         self.loading = NO;
-        
-        MPAdConfiguration *config = self.requestingConfiguration;
-        if (config != nil) {
-            [[Skillz skillzInstance] setLoadedInterstitialCreativeId:config.creativeId];
-        }
+
         NSError * clearResponseError = [NSError errorWithCode:MOPUBErrorNoInventory localizedDescription:[NSString stringWithFormat:kMPClearErrorLogFormatWithAdUnitID, self.delegate.interstitialAdController.adUnitId]];
         MPLogAdEvent([MPLogEvent adFailedToLoadWithError:clearResponseError], self.delegate.interstitialAdController.adUnitId);
         [self.delegate manager:self didFailToLoadInterstitialWithError:clearResponseError];

--- a/MoPubSDK/MPFullscreenAdAdapter.h
+++ b/MoPubSDK/MPFullscreenAdAdapter.h
@@ -127,18 +127,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleDidInvalidateAd;
 
 /**
- * Called when the interstitial should be forced to dismiss.
- */
-- (void)dismissInterstitialAnimated:(BOOL)animated;
-
-/**
  * The @c delegate object to send events to as they occur.
  *
  * @c MPFullscreenAdAdapterDelegate defines several methods that you should call in
  * order to inform MoPub of the state of your adapter.
  */
 @property (nonatomic, weak, readonly) id<MPFullscreenAdAdapterDelegate> delegate;
-
 
 @end
 

--- a/MoPubSDK/MPFullscreenAdAdapter.m
+++ b/MoPubSDK/MPFullscreenAdAdapter.m
@@ -399,11 +399,6 @@ static const NSUInteger kExcessiveCustomDataLength = 8196;
     }
 }
 
-- (void)dismissInterstitialAnimated:(BOOL)animated
-{
-    [self.viewController dismiss];
-}
-
 - (void)handleDidInvalidateAd {
     // Subclasses may override this method to handle when the adapter is no longer needed.
 }

--- a/MoPubSDK/MPInterstitialAdController.h
+++ b/MoPubSDK/MPInterstitialAdController.h
@@ -127,11 +127,6 @@
  */
 - (void)showFromViewController:(UIViewController *)controller;
 
-/**
- * Dismiss the interstitial ad if it's showing.
- */
-- (void)dismissInterstitialAnimated:(BOOL)animated;
-
 /** @name Disposing of an Interstitial Ad */
 
 /**

--- a/MoPubSDK/MPInterstitialAdController.m
+++ b/MoPubSDK/MPInterstitialAdController.m
@@ -90,11 +90,6 @@
     [self.manager presentInterstitialFromViewController:controller];
 }
 
-- (void)dismissInterstitialAnimated:(BOOL)animated
-{
-    [self.manager dismissInterstitialAnimated:animated];
-}
-
 #pragma mark - Internal
 
 + (NSMutableDictionary *)sharedInterstitials


### PR DESCRIPTION
Refactored skillz dismissal of interstitial ads which seemed to be causing a couple of issues when tapping on mopub ads.
- Fix dismissing the interstitial ad only when tapping on skillz house ads that deeplink to store. Reverted the change in adActionDidFinish that I thought fixed this last time, but caused the safariviewcontroller to close immediately after tapping.
![ios-inhouse-deeplink](https://user-images.githubusercontent.com/22797037/96026656-a88a5800-0e0b-11eb-87e0-9b398db222cc.gif)
- Fix video freezing when tapping on a video mopub ad.
![ios-video-deeplink](https://user-images.githubusercontent.com/22797037/96026886-f606c500-0e0b-11eb-860a-7443c0a3f00c.gif)
- Fix tapping on interstitial ad that launches a webpage:
![ios-outapp-deeplink](https://user-images.githubusercontent.com/22797037/96026981-120a6680-0e0c-11eb-902e-e7baf7adb59d.gif)
